### PR TITLE
Implement Retries on error config option

### DIFF
--- a/custom_components/http_agent/config_flow.py
+++ b/custom_components/http_agent/config_flow.py
@@ -19,6 +19,7 @@ from .const import (
     CONF_INTERVAL,
     CONF_METHOD,
     CONF_PAYLOAD,
+    CONF_RETRIES,
     CONF_SENSOR_COLOR,
     CONF_SENSOR_DEVICE_CLASS,
     CONF_SENSOR_ICON,
@@ -37,6 +38,7 @@ from .const import (
     CONTENT_TYPES,
     DEFAULT_INTERVAL,
     DEFAULT_METHOD,
+    DEFAULT_RETRIES,
     DEFAULT_TIMEOUT,
     DEFAULT_VERIFY_SSL,
     DOMAIN,
@@ -87,6 +89,9 @@ class HTTPAgentConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Required(CONF_METHOD, default=DEFAULT_METHOD): vol.In(HTTP_METHODS),
                 vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): vol.All(
                     vol.Coerce(int), vol.Range(min=1, max=300)
+                ),
+                vol.Required(CONF_RETRIES, default=DEFAULT_RETRIES): vol.All(
+                    vol.Coerce(int), vol.Range(min=0, max=10)
                 ),
                 vol.Optional(CONF_INTERVAL, default=DEFAULT_INTERVAL): vol.All(
                     vol.Coerce(int), vol.Range(min=5, max=86400)
@@ -426,6 +431,10 @@ class HTTPAgentOptionsFlow(config_entries.OptionsFlow):
                 vol.Optional(
                     CONF_TIMEOUT, default=self.data.get(CONF_TIMEOUT, DEFAULT_TIMEOUT)
                 ): vol.All(vol.Coerce(int), vol.Range(min=1, max=300)),
+                vol.Required(
+                    CONF_RETRIES,
+                    default=self.data.get(CONF_RETRIES, DEFAULT_RETRIES),
+                ): vol.All(vol.Coerce(int), vol.Range(min=0, max=10)),
                 vol.Optional(
                     CONF_INTERVAL,
                     default=self.data.get(CONF_INTERVAL, DEFAULT_INTERVAL),

--- a/custom_components/http_agent/const.py
+++ b/custom_components/http_agent/const.py
@@ -6,6 +6,7 @@ DOMAIN: Final = "http_agent"
 
 # Default values
 DEFAULT_TIMEOUT = 10
+DEFAULT_RETRIES = 0
 DEFAULT_INTERVAL = 60
 DEFAULT_METHOD = "GET"
 DEFAULT_VERIFY_SSL = True
@@ -14,6 +15,7 @@ DEFAULT_VERIFY_SSL = True
 CONF_URL = "url"
 CONF_METHOD = "method"
 CONF_TIMEOUT = "timeout"
+CONF_RETRIES = "retries"
 CONF_INTERVAL = "interval"
 CONF_VERIFY_SSL = "verify_ssl"
 CONF_HEADERS = "headers"

--- a/custom_components/http_agent/coordinator.py
+++ b/custom_components/http_agent/coordinator.py
@@ -6,12 +6,12 @@ import asyncio
 from datetime import timedelta
 import json
 import logging
+import re
 from typing import Any
 from xml.etree import ElementTree as ET
 
 import aiohttp
 from bs4 import BeautifulSoup
-import re
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.template import Template
@@ -23,6 +23,7 @@ from .const import (
     CONF_INTERVAL,
     CONF_METHOD,
     CONF_PAYLOAD,
+    CONF_RETRIES,
     CONF_SENSOR_COLOR,
     CONF_SENSOR_DEVICE_CLASS,
     CONF_SENSOR_ICON,
@@ -39,6 +40,7 @@ from .const import (
     CONF_URL,
     CONF_VERIFY_SSL,
     DEFAULT_INTERVAL,
+    DEFAULT_RETRIES,
     DEFAULT_TIMEOUT,
     DEFAULT_VERIFY_SSL,
     DOMAIN,
@@ -87,6 +89,7 @@ class HTTPAgentCoordinator(DataUpdateCoordinator):
         self.url = entry_data[CONF_URL]
         self.method = entry_data[CONF_METHOD]
         self.timeout = entry_data.get(CONF_TIMEOUT, DEFAULT_TIMEOUT)
+        self.retries = entry_data.get(CONF_RETRIES, DEFAULT_RETRIES)
         self.verify_ssl = entry_data.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL)
         self.headers = {h["key"]: h["value"] for h in entry_data.get(CONF_HEADERS, [])}
         self.payload = entry_data.get(CONF_PAYLOAD, "")
@@ -144,75 +147,140 @@ class HTTPAgentCoordinator(DataUpdateCoordinator):
                         kwargs["data"] = rendered_payload
                 else:
                     kwargs["data"] = rendered_payload
+            total_attempts = max(1, int(self.retries) + 1)
 
-            async with self.session.request(self.method, **kwargs) as response:
-                response_text = await response.text()
+            for attempt in range(1, total_attempts + 1):
+                try:
+                    async with self.session.request(self.method, **kwargs) as response:
+                        response_text = await response.text()
 
-                _LOGGER.debug(
-                    "HTTP request to %s returned status %s",
-                    rendered_url,
-                    response.status,
-                )
+                        # Retry on empty response or non-2xx status
+                        if (
+                            not response_text
+                            or response.status < 200
+                            or response.status >= 300
+                        ):
+                            error_msg = f"HTTP {response.status}"
+                            if not response_text:
+                                error_msg = "Empty response"
 
-                # Create custom response object for templates
-                http_response = HTTPResponse(
-                    text=response_text,
-                    status=response.status,
-                    headers=dict(response.headers),
-                )
+                            _LOGGER.debug(
+                                "HTTP request attempt %s/%s failed for %s: %s",
+                                attempt,
+                                total_attempts,
+                                rendered_url,
+                                error_msg,
+                            )
 
-                # Extract sensor data
-                sensor_data = {}
-                for sensor_config in self.sensors_config:
-                    sensor_name = sensor_config[CONF_SENSOR_NAME]
-                    sensor_type = sensor_config.get(CONF_SENSOR_TYPE, "sensor")
+                            if attempt == total_attempts:
+                                raise UpdateFailed(
+                                    f"Failed to fetch data after {attempt} attempts: {error_msg}"
+                                )
 
-                    # Base sensor values
-                    sensor_values = {
-                        "type": sensor_type,
-                        "state": self._extract_value_auto(
-                            http_response, sensor_config.get(CONF_SENSOR_STATE, "")
-                        ),
-                        "icon": self._extract_value_auto(
-                            http_response, sensor_config.get(CONF_SENSOR_ICON, "")
-                        ),
-                        "color": self._extract_value_auto(
-                            http_response, sensor_config.get(CONF_SENSOR_COLOR, "")
-                        ),
-                        "device_class": sensor_config.get(CONF_SENSOR_DEVICE_CLASS, ""),
-                        "unit": sensor_config.get(CONF_SENSOR_UNIT, ""),
-                    }
+                            # wait 1s before next attempt
+                            await asyncio.sleep(1)
 
-                    # Add device tracker specific data
-                    if sensor_type == "device_tracker":
-                        sensor_values.update(
-                            {
-                                "latitude": self._extract_value_auto(
-                                    http_response,
-                                    sensor_config.get(CONF_TRACKER_LATITUDE, ""),
-                                ),
-                                "longitude": self._extract_value_auto(
-                                    http_response,
-                                    sensor_config.get(CONF_TRACKER_LONGITUDE, ""),
-                                ),
-                                "location_name": self._extract_value_auto(
-                                    http_response,
-                                    sensor_config.get(CONF_TRACKER_LOCATION_NAME, ""),
-                                ),
-                                "source_type": sensor_config.get(
-                                    CONF_TRACKER_SOURCE_TYPE, "gps"
-                                ),
-                            }
+                            continue
+
+                        _LOGGER.debug(
+                            "HTTP request to %s returned status %s",
+                            rendered_url,
+                            response.status,
                         )
 
-                    sensor_data[sensor_name] = sensor_values
+                        # Create custom response object for templates
+                        http_response = HTTPResponse(
+                            text=response_text,
+                            status=response.status,
+                            headers=dict(response.headers),
+                        )
 
-                return sensor_data
+                        # Extract sensor data
+                        sensor_data = {}
+                        for sensor_config in self.sensors_config:
+                            sensor_name = sensor_config[CONF_SENSOR_NAME]
+                            sensor_type = sensor_config.get(CONF_SENSOR_TYPE, "sensor")
 
-        except asyncio.TimeoutError as err:
-            raise UpdateFailed(f"Timeout while fetching data: {err}") from err
-        except aiohttp.ClientError as err:
-            raise UpdateFailed(f"Error fetching data: {err}") from err
+                            # Base sensor values
+                            sensor_values = {
+                                "type": sensor_type,
+                                "state": self._extract_value_auto(
+                                    http_response,
+                                    sensor_config.get(CONF_SENSOR_STATE, ""),
+                                ),
+                                "icon": self._extract_value_auto(
+                                    http_response,
+                                    sensor_config.get(CONF_SENSOR_ICON, ""),
+                                ),
+                                "color": self._extract_value_auto(
+                                    http_response,
+                                    sensor_config.get(CONF_SENSOR_COLOR, ""),
+                                ),
+                                "device_class": sensor_config.get(
+                                    CONF_SENSOR_DEVICE_CLASS, ""
+                                ),
+                                "unit": sensor_config.get(CONF_SENSOR_UNIT, ""),
+                            }
+
+                            # Add device tracker specific data
+                            if sensor_type == "device_tracker":
+                                sensor_values.update(
+                                    {
+                                        "latitude": self._extract_value_auto(
+                                            http_response,
+                                            sensor_config.get(
+                                                CONF_TRACKER_LATITUDE, ""
+                                            ),
+                                        ),
+                                        "longitude": self._extract_value_auto(
+                                            http_response,
+                                            sensor_config.get(
+                                                CONF_TRACKER_LONGITUDE, ""
+                                            ),
+                                        ),
+                                        "location_name": self._extract_value_auto(
+                                            http_response,
+                                            sensor_config.get(
+                                                CONF_TRACKER_LOCATION_NAME, ""
+                                            ),
+                                        ),
+                                        "source_type": sensor_config.get(
+                                            CONF_TRACKER_SOURCE_TYPE, "gps"
+                                        ),
+                                    }
+                                )
+
+                            sensor_data[sensor_name] = sensor_values
+
+                        return sensor_data
+
+                except (asyncio.TimeoutError, aiohttp.ClientError) as err:
+                    err_detail = str(err) or type(err).__name__
+                    _LOGGER.debug(
+                        "HTTP request attempt %s/%s failed for %s: %s",
+                        attempt,
+                        total_attempts,
+                        rendered_url,
+                        err_detail,
+                    )
+                    if attempt == total_attempts:
+                        if isinstance(err, asyncio.TimeoutError):
+                            raise UpdateFailed(
+                                f"Timeout while fetching data after {attempt} attempts"
+                            ) from err
+                        raise UpdateFailed(
+                            f"Error fetching data after {attempt} attempts: {err_detail}"
+                        ) from err
+
+                    # wait 1s before next attempt if this was not a timeout
+                    if not isinstance(err, asyncio.TimeoutError):
+                        await asyncio.sleep(1)
+
+            # Prevent linter errors. Should never reach here - loop always returns or raises
+            raise UpdateFailed("Failed to fetch data")
+
+        except UpdateFailed:
+            raise
         except Exception as err:
             raise UpdateFailed(f"Unexpected error: {err}") from err
 
@@ -348,7 +416,7 @@ class HTTPAgentCoordinator(DataUpdateCoordinator):
 
         last_slash = selector.rfind("/")
         pattern = selector[1:last_slash]
-        flags_str = selector[last_slash + 1:]
+        flags_str = selector[last_slash + 1 :]
 
         flag_map = {
             "i": re.I,
@@ -376,7 +444,9 @@ class HTTPAgentCoordinator(DataUpdateCoordinator):
                 if match.lastindex == 1:
                     return match.group(1)
                 elif match.lastindex > 1:
-                    return "|".join(match.group(i) for i in range(1, match.lastindex + 1))
+                    return "|".join(
+                        match.group(i) for i in range(1, match.lastindex + 1)
+                    )
         except Exception:
             pass
 

--- a/custom_components/http_agent/strings.json
+++ b/custom_components/http_agent/strings.json
@@ -9,6 +9,7 @@
           "method": "HTTP Method",
           "timeout": "Timeout (seconds)",
           "interval": "Update Interval (seconds)",
+          "retries": "Retries on error",
           "verify_ssl": "Verify SSL Certificate"
         }
       },
@@ -101,6 +102,7 @@
           "method": "HTTP Method",
           "timeout": "Timeout (seconds)",
           "interval": "Update Interval (seconds)",
+          "retries": "Retries on error",
           "verify_ssl": "Verify SSL Certificate"
         }
       },

--- a/custom_components/http_agent/translations/da.json
+++ b/custom_components/http_agent/translations/da.json
@@ -9,6 +9,7 @@
           "method": "HTTP-metode",
           "timeout": "Timeout (sekunder)",
           "interval": "Opdateringsinterval (sekunder)",
+          "retries": "Genforsøg ved fejl",
           "verify_ssl": "Verificer SSL-certifikat"
         }
       },
@@ -101,6 +102,7 @@
           "method": "HTTP-metode",
           "timeout": "Timeout (sekunder)",
           "interval": "Opdateringsinterval (sekunder)",
+          "retries": "Genforsøg ved fejl",
           "verify_ssl": "Verificer SSL-certifikat"
         }
       },

--- a/custom_components/http_agent/translations/de.json
+++ b/custom_components/http_agent/translations/de.json
@@ -9,6 +9,7 @@
           "method": "HTTP-Methode",
           "timeout": "Zeitüberschreitung (Sekunden)",
           "interval": "Aktualisierungsintervall (Sekunden)",
+          "retries": "Wiederholungsversuche bei Fehlern",
           "verify_ssl": "SSL-Zertifikat verifizieren"
         }
       },
@@ -101,6 +102,7 @@
           "method": "HTTP-Methode",
           "timeout": "Zeitüberschreitung (Sekunden)",
           "interval": "Aktualisierungsintervall (Sekunden)",
+          "retries": "Wiederholungsversuche bei Fehlern",
           "verify_ssl": "SSL-Zertifikat verifizieren"
         }
       },

--- a/custom_components/http_agent/translations/en.json
+++ b/custom_components/http_agent/translations/en.json
@@ -9,6 +9,7 @@
           "method": "HTTP Method",
           "timeout": "Timeout (seconds)",
           "interval": "Update Interval (seconds)",
+          "retries": "Retries on error",
           "verify_ssl": "Verify SSL Certificate"
         }
       },
@@ -101,6 +102,7 @@
           "method": "HTTP Method",
           "timeout": "Timeout (seconds)",
           "interval": "Update Interval (seconds)",
+          "retries": "Retries on error",
           "verify_ssl": "Verify SSL Certificate"
         }
       },

--- a/custom_components/http_agent/translations/fi.json
+++ b/custom_components/http_agent/translations/fi.json
@@ -9,6 +9,7 @@
           "method": "HTTP-metodi",
           "timeout": "Aikakatkaisu (sekuntia)",
           "interval": "Päivitysväli (sekuntia)",
+          "retries": "Uudelleenyritykset virheen sattuessa",
           "verify_ssl": "Vahvista SSL-varmenne"
         }
       },
@@ -101,6 +102,7 @@
           "method": "HTTP-metodi",
           "timeout": "Aikakatkaisu (sekuntia)",
           "interval": "Päivitysväli (sekuntia)",
+          "retries": "Uudelleenyritykset virheen sattuessa",
           "verify_ssl": "Vahvista SSL-varmenne"
         }
       },

--- a/custom_components/http_agent/translations/no.json
+++ b/custom_components/http_agent/translations/no.json
@@ -9,6 +9,7 @@
           "method": "HTTP-metode",
           "timeout": "Tidsavbrudd (sekunder)",
           "interval": "Oppdateringsintervall (sekunder)",
+          "retries": "Forsøk på nytt ved feil",
           "verify_ssl": "Verifiser SSL-sertifikat"
         }
       },
@@ -101,6 +102,7 @@
           "method": "HTTP-metode",
           "timeout": "Tidsavbrudd (sekunder)",
           "interval": "Oppdateringsintervall (sekunder)",
+          "retries": "Forsøk på nytt ved feil",
           "verify_ssl": "Verifiser SSL-sertifikat"
         }
       },

--- a/custom_components/http_agent/translations/sv.json
+++ b/custom_components/http_agent/translations/sv.json
@@ -9,6 +9,7 @@
           "method": "HTTP-metod",
           "timeout": "Timeout (sekunder)",
           "interval": "Uppdateringsintervall (sekunder)",
+          "retries": "Försök igen vid fel",
           "verify_ssl": "Verifiera SSL-certifikat"
         }
       },
@@ -101,6 +102,7 @@
           "method": "HTTP-metod",
           "timeout": "Timeout (sekunder)",
           "interval": "Uppdateringsintervall (sekunder)",
+          "retries": "Försök igen vid fel",
           "verify_ssl": "Verifiera SSL-certifikat"
         }
       },


### PR DESCRIPTION
Implement a config option to allow immediately retrying a request in case of request error. Maybe it's a temporary/one-time timeout/empty response/HTTP code != 200/etc

Config:
<img width="437" height="773862" alt="image" src="https://github.com/user-attachments/assets/16e770f0-4431-4b0a-bd89-029ab89bf93a" />

------------------------------------------------

Log:
<img width="887" height="159" alt="image" src="https://github.com/user-attachments/assets/6c509acc-5cd7-466e-bdbe-142927b0da76" />
